### PR TITLE
Resolve backpropagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VSCode
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/nanograd/scalar.py
+++ b/nanograd/scalar.py
@@ -6,20 +6,21 @@ from .enums import Operation
 from .utils import topological_sort
 from ordered_set import OrderedSet
 
+
 class Scalar:
     """
     A Scalar object represents a node in the computational graph. It is central piece
     of the autograd engine since it is in charge of computing the gradient during the
     backward phase.
     """
-    
+
     def __init__(
         self,
         data: int | float,
         label: str | None = None,
         requires_grad: bool = False,
-        _prev: OrderedSet['Scalar'] = None,
-        _op: Operation = Operation.NONE
+        _prev: OrderedSet["Scalar"] = None,
+        _op: Operation = Operation.NONE,
     ) -> None:
         """Constructor."""
         self.data = data
@@ -33,17 +34,15 @@ class Scalar:
         self.requires_grad_(requires_grad)
 
     @staticmethod
-    def supported_type(x: Union[int, float, 'Scalar']) -> None:
+    def supported_type(x: Union[int, float, "Scalar"]) -> None:
         """Check that the type of the argument `x` is supported."""
         if not isinstance(x, (Scalar, int, float)):
             raise TypeError(f"The following type {type(x)} is not supported.")
 
     @staticmethod
     def as_scalar(
-        x: int | float,
-        label: str | None = None,
-        requires_grad: bool = False
-    ) -> 'Scalar':
+        x: int | float, label: str | None = None, requires_grad: bool = False
+    ) -> "Scalar":
         """Return the argument `x` as a Scalar if it is possible."""
         Scalar.supported_type(x)
         if isinstance(x, Scalar):
@@ -54,60 +53,72 @@ class Scalar:
     def requires_grad_(self, requires_grad: bool) -> None:
         """Set the `requires_grad` attribute of the object."""
         self.requires_grad = requires_grad
-        # If the object requires gradient, we need to set the `_backward` attribute to 1.0
-        # so that the gradient is computed during the backward phase.
+        # If the object requires gradient, we need to set the `_backward` attribute to
+        # 1.0 so that the gradient is computed during the backward phase.
         # Otherwise, we set it to 0.0 so that the gradient is not computed.
         self._backward = 1.0 if requires_grad else 0.0
 
-    def add(self, other: Union[int, float, 'Scalar'], label: str | None = None) -> 'Scalar':
+    def add(
+        self, other: Union[int, float, "Scalar"], label: str | None = None
+    ) -> "Scalar":
         """Addition operator."""
         out = self + other
         out.label = label
         return out
-    
-    def neg(self, label: str | None = None) -> 'Scalar':
+
+    def neg(self, label: str | None = None) -> "Scalar":
         """Negation operator."""
         out = -self
         out.label = label
         return out
-    
-    def sub(self, other: Union[int, float, 'Scalar'], label: str | None = None) -> 'Scalar':
+
+    def sub(
+        self, other: Union[int, float, "Scalar"], label: str | None = None
+    ) -> "Scalar":
         """Subtraction operator."""
         out = self - other
         out.label = label
         return out
-    
-    def mul(self, other: Union[int, float, 'Scalar'], label: str | None = None) -> 'Scalar':
+
+    def mul(
+        self, other: Union[int, float, "Scalar"], label: str | None = None
+    ) -> "Scalar":
         """Multiplication operator."""
         out = self * other
         out.label = label
         return out
-    
-    def div(self, other: Union[int, float, 'Scalar'], label: str | None = None) -> 'Scalar':
+
+    def div(
+        self, other: Union[int, float, "Scalar"], label: str | None = None
+    ) -> "Scalar":
         """Division operator."""
         out = self / other
         out.label = label
         return out
-    
-    def floordiv(self, other: Union[int, float, 'Scalar'], label: str | None = None) -> 'Scalar':
+
+    def floordiv(
+        self, other: Union[int, float, "Scalar"], label: str | None = None
+    ) -> "Scalar":
         """Floor division operator."""
         out = self // other
         out.label = label
         return out
-    
-    def invert(self, label: str | None = None) -> 'Scalar':
+
+    def invert(self, label: str | None = None) -> "Scalar":
         """Invertion operator."""
         out = self.__invert__()
         out.label = label
         return out
-    
-    def pow(self, other: Union[int, float, 'Scalar'], label: str | None = None) -> 'Scalar':
+
+    def pow(
+        self, other: Union[int, float, "Scalar"], label: str | None = None
+    ) -> "Scalar":
         """Power operator."""
-        out = self ** other
+        out = self**other
         out.label = label
         return out
-    
-    def exp(self, label: str | None = None) -> 'Scalar':
+
+    def exp(self, label: str | None = None) -> "Scalar":
         """Exponential operator."""
         # Perform the exponential.
         out = Scalar(
@@ -115,15 +126,17 @@ class Scalar:
             label=label,
             requires_grad=True,
             _prev=OrderedSet([self]),
-            _op=Operation.EXPONENTIAL
+            _op=Operation.EXPONENTIAL,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
             self._grad += self._backward * (out.data) * out._grad
+
         out._backward_fn = _backward_fn
         return out
-    
-    def tanh(self, label: str | None = None) -> 'Scalar':
+
+    def tanh(self, label: str | None = None) -> "Scalar":
         """Hyperbolic tangent operator."""
         # Perform the hyperbolic tangent.
         out = Scalar(
@@ -131,15 +144,17 @@ class Scalar:
             label=label,
             requires_grad=True,
             _prev=OrderedSet([self]),
-            _op=Operation.HYPERBOLIC_TANGENT
+            _op=Operation.HYPERBOLIC_TANGENT,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
             self._grad += self._backward * (1.0 - out.data**2) * out._grad
+
         out._backward_fn = _backward_fn
         return out
-    
-    def relu(self, label: str | None = None) -> 'Scalar':
+
+    def relu(self, label: str | None = None) -> "Scalar":
         """ReLU operator."""
         # Perform the ReLU.
         out = Scalar(
@@ -147,14 +162,16 @@ class Scalar:
             label=label,
             requires_grad=True,
             _prev=OrderedSet([self]),
-            _op=Operation.RELU
+            _op=Operation.RELU,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
             self._grad += self._backward * (1.0 if self.data > 0.0 else 0.0) * out._grad
+
         out._backward_fn = _backward_fn
         return out
-    
+
     def backward(self) -> None:
         """Backward pass."""
         # Compute the topological sort of the computational graph.
@@ -163,112 +180,130 @@ class Scalar:
         self._grad = 1.0
         for x in reversed(topo):
             x._backward_fn()
-    
-    def __add__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+
+    def __add__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Addition operator."""
-        # Check that the type of the argument is supported and cast it to a Scalar if necessary.
+        # Check that the type of the argument is supported and cast it to a Scalar if
+        # necessary.
         other = Scalar.as_scalar(other)
         # Perform the addition.
         out = Scalar(
             self.data + other.data,
             requires_grad=True,
             _prev=OrderedSet([self, other]),
-            _op=Operation.ADDITION
+            _op=Operation.ADDITION,
         )
-        # Define the backward function: the gradient of each operand is the gradient of the output
+
+        # Define the backward function: the gradient of each operand is the gradient of
+        # the output
         def _backward_fn() -> None:
             self._grad += self._backward * (1.0) * out._grad
             other._grad += other._backward * (1.0) * out._grad
+
         out._backward_fn = _backward_fn
         return out
 
-    def __radd__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+    def __radd__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Right addition operator."""
         # Addition is commutative, so we can use the __add__ method.
         return self + other
-    
-    def __neg__(self) -> 'Scalar':
+
+    def __neg__(self) -> "Scalar":
         """Negation operator."""
         # Perform the negation.
         out = Scalar(
             -self.data,
             requires_grad=True,
             _prev=OrderedSet([self]),
-            _op=Operation.NEGATION
+            _op=Operation.NEGATION,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
             self._grad += self._backward * (-1.0) * out._grad
+
         out._backward_fn = _backward_fn
         return out
 
-    def __sub__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+    def __sub__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Subtraction operator."""
-        # Check that the type of the argument is supported and cast it to a Scalar if necessary.
+        # Check that the type of the argument is supported and cast it to a Scalar if
+        # necessary.
         other = Scalar.as_scalar(other)
         # Perform the subtraction.
         out = Scalar(
             self.data - other.data,
             requires_grad=True,
             _prev=OrderedSet([self, other]),
-            _op=Operation.SUBTRACTION
+            _op=Operation.SUBTRACTION,
         )
-        # Define the backward function: the gradient of each operand is the gradient of the output
+
+        # Define the backward function: the gradient of each operand is the gradient of
+        # the output
         def _backward_fn() -> None:
             self._grad += self._backward * (1.0) * out._grad
             other._grad += other._backward * (-1.0) * out._grad
+
         out._backward_fn = _backward_fn
         return out
-    
-    def __rsub__(self, other: int | float) -> 'Scalar':
+
+    def __rsub__(self, other: int | float) -> "Scalar":
         """Right subtraction operator."""
         other = Scalar.as_scalar(other)
         out = other - self
         return out
-    
-    def __mul__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+
+    def __mul__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Multiplication operator."""
-        # Check that the type of the argument is supported and cast it to a Scalar if necessary.
+        # Check that the type of the argument is supported and cast it to a Scalar if
+        # necessary.
         other = Scalar.as_scalar(other)
         # Perform the multiplication.
         out = Scalar(
             self.data * other.data,
             requires_grad=True,
             _prev=OrderedSet([self, other]),
-            _op=Operation.MULTIPLICATION
+            _op=Operation.MULTIPLICATION,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
             self._grad += self._backward * other.data * out._grad
             other._grad += other._backward * self.data * out._grad
+
         out._backward_fn = _backward_fn
         return out
-    
-    def __rmul__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+
+    def __rmul__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Right multiplication operator."""
         # Multiplication is commutative, so we can use the __mul__ method.
         other = Scalar.as_scalar(other)
         return other * self
-    
-    def __truediv__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+
+    def __truediv__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """True division operator."""
-        # Check that the type of the argument is supported and cast it to a Scalar if necessary.
+        # Check that the type of the argument is supported and cast it to a Scalar if
+        # necessary.
         other = Scalar.as_scalar(other)
         # Perform the division
         out = Scalar(
             self.data / other.data,
             requires_grad=True,
             _prev=OrderedSet([self, other]),
-            _op=Operation.DIVISION
+            _op=Operation.DIVISION,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
             self._grad += self._backward * (1.0 / other.data) * out._grad
-            other._grad += other._backward * (-self.data / (other.data**2)) * out._grad
+            other._grad += (
+                other._backward * (-self.data / (other.data**2)) * out._grad
+            )
+
         out._backward_fn = _backward_fn
         return out
-    
-    def __rtruediv__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+
+    def __rtruediv__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Right true division operator."""
         # Division is a non-commutative operator, we cannot re-use the code of the
         # __truediv__ method directly.
@@ -276,17 +311,19 @@ class Scalar:
         out = other / self
         return out
 
-    def __floordiv__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+    def __floordiv__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Floor division operator."""
-        # Check that the type of the argument is supported and cast it to a Scalar if necessary.
+        # Check that the type of the argument is supported and cast it to a Scalar if
+        # necessary.
         other = Scalar.as_scalar(other)
         # Perform the floor division
         out = Scalar(
             self.data // other.data,
             requires_grad=True,
             _prev=OrderedSet([self, other]),
-            _op=Operation.FLOOR_DIVISION
+            _op=Operation.FLOOR_DIVISION,
         )
+
         # Define the backward function
         # Floor division is somewhat similar to the step function, its gradient
         # is zero everywhere except at the integer values where it is undefined.
@@ -294,68 +331,86 @@ class Scalar:
         def _backward_fn() -> None:
             self._grad += self._backward * 0.0 * out._grad
             other._grad += other._backward * 0.0 * out._grad
+
         out._backward_fn = _backward_fn
         return out
-    
-    def __rfloordiv__(self, other: int | float) -> 'Scalar':
+
+    def __rfloordiv__(self, other: int | float) -> "Scalar":
         """Right floor division operator."""
         # Because gradient is always zero, we can re-use the code of the
         # __floordiv__ method directly.
         other = Scalar.as_scalar(other)
         out = other // self
         return out
-    
-    def __invert__(self) -> 'Scalar':
+
+    def __invert__(self) -> "Scalar":
         """Inverse operator."""
         # Perform the invertion operation
         out = Scalar(
             self.data ** (-1.0),
             requires_grad=True,
             _prev=OrderedSet([self]),
-            _op=Operation.INVERTION
+            _op=Operation.INVERTION,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
-            self._grad += self._backward * ((-1.0)/(self.data**2)) * out._grad
+            self._grad += self._backward * ((-1.0) / (self.data**2)) * out._grad
+
         out._backward_fn = _backward_fn
         return out
-    
-    def __pow__(self, other: Union[int, float, 'Scalar']) -> 'Scalar':
+
+    def __pow__(self, other: Union[int, float, "Scalar"]) -> "Scalar":
         """Exponentiation operator."""
-        # Check that the type of the argument is supported and cast it to a Scalar if necessary.
+        # Check that the type of the argument is supported and cast it to a Scalar if
+        # necessary.
         other = Scalar.as_scalar(other)
         # Perform the exponentiation
         out = Scalar(
-            self.data ** other.data,
+            self.data**other.data,
             requires_grad=True,
             _prev=OrderedSet([self, other]),
-            _op=Operation.EXPONENTIATION
+            _op=Operation.EXPONENTIATION,
         )
+
         # Define the backward function
         def _backward_fn() -> None:
-            self._grad += self._backward * (other.data * ((self.data) ** (other.data - 1.0))) * out._grad
-            other._grad += other._backward * (log(self.data) * (self.data ** other.data)) * out._grad
+            self._grad += (
+                self._backward
+                * (other.data * ((self.data) ** (other.data - 1.0)))
+                * out._grad
+            )
+            other._grad += (
+                other._backward
+                * (log(self.data) * (self.data**other.data))
+                * out._grad
+            )
+
         out._backward_fn = _backward_fn
         return out
-    
-    def __rpow__(self, other: int | float) -> 'Scalar':
+
+    def __rpow__(self, other: int | float) -> "Scalar":
         """Right exponentiation operator."""
         # Exponentiation is a non-commutative operator, we cannot re-use the code of the
         # __pow__ method directly.
         other = Scalar.as_scalar(other)
-        out = other ** self
+        out = other**self
         return out
-        
+
     def __str__(self) -> str:
         """Provide a string representation of the object."""
         label_str = "" if self.label is None else f"label={self.label}, "
         data_str = f"data={self.data:.6f}"
-        req_grad_str = "" if not self.requires_grad else f", requires_grad={self.requires_grad}"
+        req_grad_str = (
+            "" if not self.requires_grad else f", requires_grad={self.requires_grad}"
+        )
         grad_str = "" if not self.requires_grad else f", grad={self._grad:.6f}"
         op_str = "" if self._op is Operation.NONE else f", op={self._op.value}"
         prev_str = "" if self._op is Operation.NONE else f", prev={len(self._prev)}"
-        return f"Scalar({label_str}{data_str}{req_grad_str}{grad_str}{op_str}{prev_str})"
-        
+        return (
+            f"Scalar({label_str}{data_str}{req_grad_str}{grad_str}{op_str}{prev_str})"
+        )
+
     def __repr__(self) -> str:
         """Provide an information-rich string representation of the object."""
         start_str = "Scalar\n"
@@ -364,7 +419,14 @@ class Scalar:
         requires_grad_str = f"{' ':3}requires_grad : {self.requires_grad}\n"
         grad_str = f"{' ':3}grad          : {self._grad:.6f}\n"
         op_str = f"{' ':3}op            : {self._op.value}\n"
-        children_str = ''.join([f"\n{' ':6}{child}" for child in self._prev]) if len(self._prev) > 0 else "None"
+        children_str = (
+            "".join([f"\n{' ':6}{child}" for child in self._prev])
+            if len(self._prev) > 0
+            else "None"
+        )
         prev_str = f"{' ':3}prev          : {children_str}"
 
-        return f"{start_str}{label_str}{data_str}{requires_grad_str}{grad_str}{op_str}{prev_str}"
+        return (
+            f"{start_str}{label_str}{data_str}"
+            f"{requires_grad_str}{grad_str}{op_str}{prev_str}"
+        )

--- a/nanograd/types.py
+++ b/nanograd/types.py
@@ -1,6 +1,0 @@
-"""Module containing types for nanograd."""
-
-from .scalar import Scalar
-
-# Type of a node in the computational graph.
-_NodeLike = Scalar

--- a/nanograd/types.py
+++ b/nanograd/types.py
@@ -1,0 +1,6 @@
+"""Module containing types for nanograd."""
+
+from .scalar import Scalar
+
+# Type of a node in the computational graph.
+_NodeLike = Scalar

--- a/nanograd/utils.py
+++ b/nanograd/utils.py
@@ -1,15 +1,11 @@
 """Module containing utility functions for nanograd."""
 
-from typing import TYPE_CHECKING
 from ordered_set import OrderedSet
 
-if TYPE_CHECKING:
-    from .scalar import Scalar
-
-def topological_sort(root: 'Scalar') -> OrderedSet['Scalar']:
+def topological_sort(root) -> OrderedSet:
         """Topological sort of the computational graph."""
         topo, visited = OrderedSet(), set()
-        def _topological_sort(node: 'Scalar') -> None:
+        def _topological_sort(node) -> None:
             if node not in visited:
                 visited.add(node)
                 for prev in node._prev:

--- a/nanograd/utils.py
+++ b/nanograd/utils.py
@@ -1,18 +1,19 @@
 """Module containing utility functions for nanograd."""
 
 from typing import TYPE_CHECKING
+from ordered_set import OrderedSet
 
 if TYPE_CHECKING:
     from .scalar import Scalar
 
-def topological_sort(root: 'Scalar') -> set['Scalar']:
+def topological_sort(root: 'Scalar') -> OrderedSet['Scalar']:
         """Topological sort of the computational graph."""
-        topo, visited = set(), set()
+        topo, visited = OrderedSet(), set()
         def _topological_sort(node: 'Scalar') -> None:
             if node not in visited:
                 visited.add(node)
                 for prev in node._prev:
                     _topological_sort(prev)
-                topo.add(node)
+                topo.append(node)
         _topological_sort(root)
         return topo

--- a/nanograd/utils.py
+++ b/nanograd/utils.py
@@ -1,0 +1,15 @@
+"""Module containing utility functions for nanograd."""
+
+from .types import _NodeLike
+
+def topological_sort(self) -> set[_NodeLike]:
+        """Topological sort of the computational graph."""
+        topo, visited = set(), set()
+        def _topological_sort(node: _NodeLike) -> None:
+            if node not in visited:
+                visited.add(node)
+                for prev in node._prev:
+                    _topological_sort(prev)
+                topo.add(node)
+        _topological_sort(self)
+        return topo

--- a/nanograd/utils.py
+++ b/nanograd/utils.py
@@ -1,11 +1,14 @@
 """Module containing utility functions for nanograd."""
 
-from .types import _NodeLike
+from typing import TYPE_CHECKING
 
-def topological_sort(root: _NodeLike) -> set[_NodeLike]:
+if TYPE_CHECKING:
+    from .scalar import Scalar
+
+def topological_sort(root: 'Scalar') -> set['Scalar']:
         """Topological sort of the computational graph."""
         topo, visited = set(), set()
-        def _topological_sort(node: _NodeLike) -> None:
+        def _topological_sort(node: 'Scalar') -> None:
             if node not in visited:
                 visited.add(node)
                 for prev in node._prev:

--- a/nanograd/utils.py
+++ b/nanograd/utils.py
@@ -2,7 +2,7 @@
 
 from .types import _NodeLike
 
-def topological_sort(self) -> set[_NodeLike]:
+def topological_sort(root: _NodeLike) -> set[_NodeLike]:
         """Topological sort of the computational graph."""
         topo, visited = set(), set()
         def _topological_sort(node: _NodeLike) -> None:
@@ -11,5 +11,5 @@ def topological_sort(self) -> set[_NodeLike]:
                 for prev in node._prev:
                     _topological_sort(prev)
                 topo.add(node)
-        _topological_sort(self)
+        _topological_sort(root)
         return topo

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,8 +1,11 @@
 attrs==22.2.0
+black==23.1.0
 bleach==6.0.0
 certifi==2022.12.7
 charset-normalizer==3.0.1
+click==8.1.3
 colorama==0.4.6
+coverage==7.2.0
 docutils==0.19
 exceptiongroup==1.1.0
 idna==3.4
@@ -13,11 +16,16 @@ keyring==23.13.1
 markdown-it-py==2.2.0
 mdurl==0.1.2
 more-itertools==9.0.0
+mypy-extensions==1.0.0
+ordered-set==4.1.0
 packaging==23.0
+pathspec==0.11.0
 pkginfo==1.9.6
+platformdirs==3.1.0
 pluggy==1.0.0
 Pygments==2.14.0
 pytest==7.2.1
+pytest-cov==4.0.0
 pytest-runner==6.0.0
 pywin32-ctypes==0.2.0
 readme-renderer==37.3
@@ -25,6 +33,7 @@ requests==2.28.2
 requests-toolbelt==0.10.1
 rfc3986==2.0.0
 rich==13.3.1
+ruff==0.0.253
 six==1.16.0
 tomli==2.0.1
 twine==4.0.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ setup(
     name='nanograd',
     packages=find_packages(include=['nanograd']),
     version='0.1.0',
-    description='A tiny scalar-valued autograd engine inspired from the one created by Karpathy',
+    description="""A tiny scalar-valued autograd engine inspired from the one created by
+    Karpathy""",
     author='François-Marie Manicacci',
     license='MIT',
     install_requires=[],

--- a/tests/test_scalar/test__add__.py
+++ b/tests/test_scalar/test__add__.py
@@ -1,8 +1,9 @@
 """Test suit for the __add__ method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__add__int() -> None:
     """Test that the addition operator works when the argument is an int."""
@@ -14,13 +15,12 @@ def test__add__int() -> None:
     assert z.requires_grad
     assert z._op == Operation.ADDITION
     # Check that the children of the output are correct.
-    assert len(z._prev) == 2
-    assert x in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert y.data == 1
     assert not y.requires_grad
     assert y._op == Operation.NONE
     assert len(y._prev) == 0
-    assert y.label == None
+    assert y.label is None
 
 
 def test__add__float() -> None:
@@ -33,13 +33,12 @@ def test__add__float() -> None:
     assert z.requires_grad
     assert z._op == Operation.ADDITION
     # Check that the children of the output are correct.
-    assert len(z._prev) == 2
-    assert x in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert y.data == 1.0
     assert not y.requires_grad
     assert y._op == Operation.NONE
     assert len(y._prev) == 0
-    assert y.label == None
+    assert y.label is None
 
 
 def test__add__scalar() -> None:
@@ -52,13 +51,14 @@ def test__add__scalar() -> None:
     assert z.requires_grad
     assert z._op == Operation.ADDITION
     # Check that the children of the output are correct.
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
 
 
 def test__add__unsupported_type() -> None:
-    """Test that the addition operator raises a TypeError when the argument is not supported."""
+    """
+    Test that the addition operator raises a TypeError when the argument is not
+    supported.
+    """
     x = Scalar(1.0, requires_grad=True)
     with raises(TypeError):
         x + "1"

--- a/tests/test_scalar/test__floordiv__.py
+++ b/tests/test_scalar/test__floordiv__.py
@@ -1,8 +1,9 @@
 """Test suite for the method __floordiv__ of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__floordiv__int_int() -> None:
     """Test the floor division operator with an integer."""
@@ -16,7 +17,7 @@ def test__floordiv__int_int() -> None:
     assert type(z.data) == int
     assert z.data == 3
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 0.0
     assert y._grad == 0.0
 
@@ -33,7 +34,7 @@ def test__floordiv__int_float() -> None:
     assert type(z.data) == float
     assert z.data == 3.0
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 0.0
     assert y._grad == 0.0
 
@@ -49,7 +50,7 @@ def test__floordiv__int_scalar() -> None:
     assert type(z.data) == float
     assert z.data == 3.0
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 0.0
     assert y._grad == 0.0
 

--- a/tests/test_scalar/test__invert__.py
+++ b/tests/test_scalar/test__invert__.py
@@ -3,6 +3,7 @@
 from math import isclose
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test__invert() -> None:
     """Test the __invert__ method."""
@@ -12,7 +13,7 @@ def test__invert() -> None:
     z._backward_fn()
     
     assert isclose(z.data, x.data ** (-1.0))
-    assert z._prev == {x}
+    assert z._prev == OrderedSet([x])
     assert z._op == Operation.INVERTION
     assert isclose(x._grad, (-1.0)/(x.data**2))
     

--- a/tests/test_scalar/test__mul__.py
+++ b/tests/test_scalar/test__mul__.py
@@ -1,8 +1,9 @@
 """Test suit for the __mul__ method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__mul__int() -> None:
     """Test the __mul__ method with an int as argument."""
@@ -14,9 +15,7 @@ def test__mul__int() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == y.data
     assert y._grad == x.data
 
@@ -31,9 +30,7 @@ def test__mul__float() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == y.data
     assert y._grad == x.data
 
@@ -47,9 +44,7 @@ def test__mul__scalar() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == y.data
     assert y._grad == x.data
 

--- a/tests/test_scalar/test__neg__.py
+++ b/tests/test_scalar/test__neg__.py
@@ -2,6 +2,7 @@
 
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_negation() -> None:
     """Test the negation operator."""
@@ -11,5 +12,5 @@ def test_negation() -> None:
     y._backward_fn()
     assert y.data == -x.data
     assert y._op == Operation.NEGATION
-    assert y._prev == {x}
+    assert y._prev == OrderedSet([x])
     assert x._grad == -1.0

--- a/tests/test_scalar/test__pow__.py
+++ b/tests/test_scalar/test__pow__.py
@@ -1,9 +1,10 @@
 """Test suite for the __pow__ method of the Scalar object."""
 
 from math import log, isclose
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__pow__int() -> None:
     """Test the __pow__ method with an argument of type int."""
@@ -15,7 +16,7 @@ def test__pow__int() -> None:
     z._backward_fn()
     
     assert isclose(z.data, 9.0)
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert z._op == Operation.EXPONENTIATION
     assert isclose(x._grad, 6.0)
     assert isclose(y._grad, log(x.data) * (x.data ** y.data))
@@ -31,7 +32,7 @@ def test__pow__float() -> None:
     z._backward_fn()
     
     assert isclose(z.data, 9.0)
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert z._op == Operation.EXPONENTIATION
     assert isclose(x._grad, 6.0)
     assert isclose(y._grad, log(x.data) * (x.data ** y.data))
@@ -46,7 +47,7 @@ def test__pow__scalar() -> None:
     z._backward_fn()
     
     assert isclose(z.data, 9.0)
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert z._op == Operation.EXPONENTIATION
     assert isclose(x._grad, 6.0)
     assert isclose(y._grad, log(x.data) * (x.data ** y.data))

--- a/tests/test_scalar/test__radd__.py
+++ b/tests/test_scalar/test__radd__.py
@@ -1,8 +1,9 @@
 """Test suit for the __radd__ method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__radd__int() -> None:
     """Test that the right addition operator works when the argument is an int."""
@@ -14,13 +15,12 @@ def test__radd__int() -> None:
     assert z.requires_grad
     assert z._op == Operation.ADDITION
     # Check that the children of the output are correct.
-    assert len(z._prev) == 2
-    assert x in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert y.data == 1
     assert not y.requires_grad
     assert y._op == Operation.NONE
     assert len(y._prev) == 0
-    assert y.label == None
+    assert y.label is None
 
 
 def test__radd__float() -> None:
@@ -33,17 +33,19 @@ def test__radd__float() -> None:
     assert z.requires_grad
     assert z._op == Operation.ADDITION
     # Check that the children of the output are correct.
-    assert len(z._prev) == 2
-    assert x in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert y.data == 1.0
     assert not y.requires_grad
     assert y._op == Operation.NONE
     assert len(y._prev) == 0
-    assert y.label == None
+    assert y.label is None
 
 
 def test__radd__unsupported_type() -> None:
-    """Test that the right addition operator raises a TypeError when the argument is not a supported type."""
+    """
+    Test that the right addition operator raises a TypeError when the argument is not a
+    supported type.
+    """
     x = Scalar(1.0, requires_grad=True)
     with raises(TypeError):
         x + '1'

--- a/tests/test_scalar/test__repr__.py
+++ b/tests/test_scalar/test__repr__.py
@@ -2,6 +2,7 @@
 
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_repr_no_label_op_none() -> None:
     a = Scalar(21)
@@ -34,7 +35,7 @@ def test_repr_with_label_op_none() -> None:
 
 
 def test_repr_no_label_op_identity() -> None:
-    a = Scalar(21, _op=Operation.IDENTITY, _prev={Scalar(21),})
+    a = Scalar(21, _op=Operation.IDENTITY, _prev=OrderedSet([Scalar(21)]))
     repr_str = a.__repr__()
     exp_repr = (
         "Scalar\n"
@@ -50,7 +51,13 @@ def test_repr_no_label_op_identity() -> None:
 
 
 def test_repr_with_label_op_identity_requires_grad() -> None:
-    a = Scalar(21, label="a", requires_grad=True, _op=Operation.IDENTITY, _prev={Scalar(21),})
+    a = Scalar(
+        21,
+        label="a",
+        requires_grad=True,
+        _op=Operation.IDENTITY,
+        _prev=OrderedSet([Scalar(21)])
+    )
     repr_str = a.__repr__()
     exp_repr = (
         "Scalar\n"

--- a/tests/test_scalar/test__rfloordiv__.py
+++ b/tests/test_scalar/test__rfloordiv__.py
@@ -1,8 +1,9 @@
 """Test suite for the __rfloordiv__ method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__rfloordiv__int() -> None:
     """Test the __rfloordiv__ method of the Scalar object with an int."""
@@ -15,7 +16,7 @@ def test__rfloordiv__int() -> None:
 
     assert z.data == 1.0
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([y, x])
     assert x._grad == 0.0
     assert y._grad == 0.0
 
@@ -31,7 +32,7 @@ def test__rfloordiv__float() -> None:
 
     assert z.data == 1.0
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([y, x])
     assert x._grad == 0.0
     assert y._grad == 0.0
 

--- a/tests/test_scalar/test__rmul__.py
+++ b/tests/test_scalar/test__rmul__.py
@@ -1,8 +1,9 @@
 """Test suit for the __rmul__ method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__rmul__int() -> None:
     """Test the __rmul__ method with an int as argument."""
@@ -14,9 +15,7 @@ def test__rmul__int() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([y, x])
     assert x._grad == y.data
     assert y._grad == x.data
 
@@ -31,9 +30,7 @@ def test__rmul__float() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([y, x])
     assert x._grad == y.data
     assert y._grad == x.data
 

--- a/tests/test_scalar/test__rpow__.py
+++ b/tests/test_scalar/test__rpow__.py
@@ -1,9 +1,10 @@
 """Test suite for the __rpow__ method of the Scalar object."""
 
 from math import isclose, log
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__rpow__int() -> None:
     """Test the __rpow__ method of the Scalar object with an int."""
@@ -16,7 +17,7 @@ def test__rpow__int() -> None:
 
     assert z.data == 4.0
     assert z._op == Operation.EXPONENTIATION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([y, x])
     assert isclose(x._grad, (y.data**x.data) * log(y.data))
     assert isclose(y._grad, (y.data**(x.data-1))* x.data)
 
@@ -32,7 +33,7 @@ def test__rpow__float() -> None:
 
     assert z.data == 4.0
     assert z._op == Operation.EXPONENTIATION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([y, x])
     assert isclose(x._grad, (y.data**x.data) * log(y.data))
     assert isclose(y._grad, (y.data**(x.data-1))* x.data)
 

--- a/tests/test_scalar/test__rsub__.py
+++ b/tests/test_scalar/test__rsub__.py
@@ -5,6 +5,7 @@ from nanograd.enums import Operation
 from ordered_set import OrderedSet
 from pytest import raises
 
+
 def test__rsub__int() -> None:
     """Test the __rsub__ method with an int."""
     x = Scalar(2, requires_grad=True)
@@ -19,6 +20,7 @@ def test__rsub__int() -> None:
     assert z._prev == OrderedSet([y, x])
     assert x._grad == -1.0
     assert y._grad == 1.0
+
 
 def test__rsub__float() -> None:
     """Test the __rsub__ method with a float."""
@@ -55,4 +57,4 @@ def test__rsub__unsupported() -> None:
     """Test the __rsub__ method with an unsupported type."""
     x = Scalar(2.0, requires_grad=True)
     with raises(TypeError):
-        z = "1.0" - x
+        "1.0" - x

--- a/tests/test_scalar/test__rsub__.py
+++ b/tests/test_scalar/test__rsub__.py
@@ -1,8 +1,9 @@
 """Test suit for the __rsub__ method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__rsub__int() -> None:
     """Test the __rsub__ method with an int."""
@@ -15,9 +16,7 @@ def test__rsub__int() -> None:
 
     assert z.data == -1
     assert z._op == Operation.SUBTRACTION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([y, x])
     assert x._grad == -1.0
     assert y._grad == 1.0
 
@@ -32,9 +31,7 @@ def test__rsub__float() -> None:
 
     assert z.data == -1.0
     assert z._op == Operation.SUBTRACTION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([y, x])
     assert x._grad == -1.0
     assert y._grad == 1.0
 
@@ -49,9 +46,7 @@ def test__rsub__scalar() -> None:
 
     assert z.data == -1.0
     assert z._op == Operation.SUBTRACTION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([y, x])
     assert x._grad == -1.0
     assert y._grad == 1.0
 

--- a/tests/test_scalar/test__rtruediv__.py
+++ b/tests/test_scalar/test__rtruediv__.py
@@ -39,7 +39,9 @@ def test__rtruediv__float() -> None:
 
 
 def test__rtruediv__not_supported() -> None:
-    """Test the __rtruediv__ method with an argument with a type that is not supported."""
+    """
+    Test the __rtruediv__ method with an argument with a type that is not supported.
+    """
     y = Scalar(2.0, requires_grad=True)
     with raises(TypeError):
         "4.0" / y

--- a/tests/test_scalar/test__rtruediv__.py
+++ b/tests/test_scalar/test__rtruediv__.py
@@ -1,9 +1,10 @@
 """Test suit for the __rtruediv__ method of the Scalar object."""
 
 from math import isclose
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__rtruediv__int() -> None:
     """Test the __rtruediv__ method with an argument of type int."""
@@ -16,7 +17,7 @@ def test__rtruediv__int() -> None:
     
     assert z.data == 2.0
     assert z._op == Operation.DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert isclose(x._grad, 1.0 / y.data)
     assert isclose(y._grad, -x.data / (y.data**2))
 
@@ -32,7 +33,7 @@ def test__rtruediv__float() -> None:
     
     assert z.data == 2.0
     assert z._op == Operation.DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert isclose(x._grad, 1.0 / y.data)
     assert isclose(y._grad, -x.data / (y.data**2))
 

--- a/tests/test_scalar/test__str__.py
+++ b/tests/test_scalar/test__str__.py
@@ -32,7 +32,21 @@ def test_str_with_label_op_identity() -> None:
 
 
 def test_str_with_label_op_identity_requires_grad() -> None:
-    a = Scalar(21, label="a", requires_grad=True, _op=Operation.IDENTITY, _prev={Scalar(21),})
+    a = Scalar(
+        21,
+        label="a",
+        requires_grad=True,
+        _op=Operation.IDENTITY,
+        _prev={Scalar(21),}
+    )
     str_repr = a.__str__()
-    exp_repr = "Scalar(label=a, data=21.000000, requires_grad=True, grad=0.000000, op=identity, prev=1)"
+    exp_repr = (
+        "Scalar("
+        "label=a, "
+        "data=21.000000, "
+        "requires_grad=True, "
+        "grad=0.000000, "
+        "op=identity, "
+        "prev=1)"
+    )
     assert str_repr == exp_repr

--- a/tests/test_scalar/test__sub__.py
+++ b/tests/test_scalar/test__sub__.py
@@ -1,8 +1,9 @@
 """Test suit for the __sub__ method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__sub__int() -> None:
     """Test the __sub__ method with an int."""
@@ -15,9 +16,7 @@ def test__sub__int() -> None:
 
     assert z.data == -1
     assert z._op == Operation.SUBTRACTION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 1.0
     assert y._grad == -1.0
 
@@ -33,9 +32,7 @@ def test__sub__float() -> None:
 
     assert z.data == -1.0
     assert z._op == Operation.SUBTRACTION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 1.0
     assert y._grad == -1.0
 
@@ -50,9 +47,7 @@ def test__sub__Scalar() -> None:
 
     assert z.data == -1.0
     assert z._op == Operation.SUBTRACTION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 1.0
     assert y._grad == -1.0
 

--- a/tests/test_scalar/test__truediv__.py
+++ b/tests/test_scalar/test__truediv__.py
@@ -1,9 +1,10 @@
 """Test suit for the method __truediv__ of the Scalar object."""
 
 from math import isclose
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test__truediv__int() -> None:
     """Test the __truediv__ method with an argument of type int."""
@@ -16,7 +17,7 @@ def test__truediv__int() -> None:
     
     assert z.data == 2.0
     assert z._op == Operation.DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert isclose(x._grad, 1 / y.data)
     assert isclose(y._grad, -x.data / (y.data**2))
 
@@ -32,7 +33,7 @@ def test__truediv__float() -> None:
     
     assert z.data == 2.0
     assert z._op == Operation.DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert isclose(x._grad, 1 / y.data)
     assert isclose(y._grad, -x.data / (y.data**2))
 
@@ -47,7 +48,7 @@ def test__truediv__scalar() -> None:
     
     assert z.data == 2.0
     assert z._op == Operation.DIVISION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert isclose(x._grad, 1 / y.data)
     assert isclose(y._grad, -x.data / (y.data**2))
     

--- a/tests/test_scalar/test_add.py
+++ b/tests/test_scalar/test_add.py
@@ -2,6 +2,7 @@
 
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_add() -> None:
     """Test that the add method works properly."""
@@ -15,8 +16,6 @@ def test_add() -> None:
     assert z.label == label
     assert z.requires_grad
     assert z._op == Operation.ADDITION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 1.0
     assert y._grad == 1.0

--- a/tests/test_scalar/test_as_scalar.py
+++ b/tests/test_scalar/test_as_scalar.py
@@ -1,7 +1,7 @@
 """Test suit for the static method `as_scalar`."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
+from pytest import raises
 
 def test_as_scalar_int() -> None:
     a = 21

--- a/tests/test_scalar/test_backward.py
+++ b/tests/test_scalar/test_backward.py
@@ -1,0 +1,35 @@
+"""Test suite for the backward method of the Scalar object."""
+
+from math import isclose
+from nanograd.scalar import Scalar
+
+def test_backward() -> None:
+    """Test of the backward method of the Scalar object."""
+    x1 = Scalar(-3.0)
+    w1 = Scalar(1.0)
+    x1w1 = x1 * w1
+    x2 = Scalar(1.0)
+    w2 = Scalar(0.5)
+    x2w2 = x2 * w2
+    x1w1x2w2 = x1w1 + x2w2
+    b = Scalar(3.0)
+    x1w1x2w2b = x1w1x2w2 + b
+    out = x1w1x2w2b.tanh()
+    out.backward()
+    
+    x1w1x2w2b_expected_grad = 1.0 - out.data**2
+    x1w1x2w2_expected_grad = 1.0 * x1w1x2w2b_expected_grad
+    x1w1_expected_grad = 1.0 * x1w1x2w2_expected_grad
+    x2w2_expected_grad = x1w1_expected_grad
+
+    assert isclose(out.data, 0.4621171573)
+    assert out._grad == 1.0
+    assert isclose(x1w1x2w2b._grad, x1w1x2w2b_expected_grad)
+    assert isclose(x1w1x2w2._grad, x1w1x2w2_expected_grad)
+    assert b._grad == 0.0
+    assert isclose(x1w1._grad, x1w1_expected_grad)
+    assert isclose(x2w2._grad, x2w2_expected_grad)
+    assert x1._grad == 0.0
+    assert w1._grad == 0.0
+    assert x2._grad == 0.0
+    assert w2._grad == 0.0

--- a/tests/test_scalar/test_exp.py
+++ b/tests/test_scalar/test_exp.py
@@ -3,6 +3,7 @@
 from math import isclose, log
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_exp_with_label() -> None:
     """Test the exp method of the Scalar object with a label."""
@@ -13,6 +14,6 @@ def test_exp_with_label() -> None:
 
     assert y.data == 2.0
     assert y.label == 'y'
-    assert y._prev == {x}
+    assert y._prev == OrderedSet([x])
     assert y._op == Operation.EXPONENTIAL
     assert isclose(x._grad, y.data)

--- a/tests/test_scalar/test_floordiv.py
+++ b/tests/test_scalar/test_floordiv.py
@@ -1,8 +1,9 @@
 """Test suite for the floordiv method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test_floordiv_int() -> None:
     """Test the floordiv method of the Scalar object with an int."""
@@ -15,7 +16,7 @@ def test_floordiv_int() -> None:
 
     assert z.data == 1.0
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 0.0
     assert y._grad == 0.0
 
@@ -31,7 +32,7 @@ def test_floordiv_float() -> None:
 
     assert z.data == 1.0
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 0.0
     assert y._grad == 0.0
 
@@ -46,7 +47,7 @@ def test_floordiv_scalar() -> None:
 
     assert z.data == 1.0
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 0.0
     assert y._grad == 0.0
 
@@ -69,6 +70,6 @@ def test_floordiv_label() -> None:
     assert z.data == 1.0
     assert z.label == "z"
     assert z._op == Operation.FLOOR_DIVISION
-    assert z._prev == {y, x}
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 0.0
     assert y._grad == 0.0

--- a/tests/test_scalar/test_invert.py
+++ b/tests/test_scalar/test_invert.py
@@ -3,6 +3,7 @@
 from math import isclose
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_invert_with_label() -> None:
     """Test the invert method with a label."""
@@ -13,7 +14,7 @@ def test_invert_with_label() -> None:
     
     assert isclose(z.data, x.data**-1)
     assert z.label == 'z'
-    assert z._prev == {x}
+    assert z._prev == OrderedSet([x])
     assert z._op == Operation.INVERTION
     assert isclose(x._grad, -1.0/(x.data**2))
     

--- a/tests/test_scalar/test_mul.py
+++ b/tests/test_scalar/test_mul.py
@@ -1,8 +1,9 @@
 """Test suit for the mul method of the Scalar object."""
 
-from pytest import raises
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
+from pytest import raises
 
 def test_mul_int() -> None:
     """Test the mul method with an int as argument."""
@@ -14,9 +15,7 @@ def test_mul_int() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == y.data
     assert y._grad == x.data
 
@@ -31,9 +30,7 @@ def test_mul_float() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == y.data
     assert y._grad == x.data
 
@@ -47,9 +44,7 @@ def test_mul_scalar() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == y.data
     assert y._grad == x.data
 
@@ -71,9 +66,7 @@ def test_mul_with_label() -> None:
     z._backward_fn()
     assert z.data == 4.0
     assert z._op == Operation.MULTIPLICATION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == y.data
     assert y._grad == x.data
     assert z.label == "z"

--- a/tests/test_scalar/test_neg.py
+++ b/tests/test_scalar/test_neg.py
@@ -2,6 +2,7 @@
 
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_neg() -> None:
     """Test the neg method of the Scalar object."""
@@ -12,5 +13,5 @@ def test_neg() -> None:
     assert y.data == -x.data
     assert y.label == "-x"
     assert y._op == Operation.NEGATION
-    assert y._prev == {x}
+    assert y._prev == OrderedSet([x])
     assert x._grad == -1.0

--- a/tests/test_scalar/test_pow.py
+++ b/tests/test_scalar/test_pow.py
@@ -3,6 +3,7 @@
 from math import isclose, log
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_pow_with_label() -> None:
     """Test the pow method of the Scalar object with a label."""
@@ -14,7 +15,7 @@ def test_pow_with_label() -> None:
 
     assert z.data == 8.0
     assert z._op == Operation.EXPONENTIATION
-    assert z._prev == {x, y}
+    assert z._prev == OrderedSet([x, y])
     assert z.label == "z"
     assert isclose(x._grad, (x.data**(y.data-1.0)) * y.data)
     assert isclose(y._grad, (x.data**y.data) * log(x.data))

--- a/tests/test_scalar/test_relu.py
+++ b/tests/test_scalar/test_relu.py
@@ -2,6 +2,7 @@
 
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_relu_with_label() -> None:
     """Test of the relu method with a label."""
@@ -12,6 +13,6 @@ def test_relu_with_label() -> None:
 
     assert y.data == 1.0
     assert y.label == "y"
-    assert y._prev == {x}
+    assert y._prev == OrderedSet([x])
     assert y._op == Operation.RELU
     assert x._grad == 1.0

--- a/tests/test_scalar/test_sub.py
+++ b/tests/test_scalar/test_sub.py
@@ -2,6 +2,7 @@
 
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_sub_with_label() -> None:
     """Test the sub method with a label."""
@@ -13,9 +14,7 @@ def test_sub_with_label() -> None:
 
     assert z.data == -1.0
     assert z._op == Operation.SUBTRACTION
-    assert len(z._prev) == 2
-    assert x in z._prev
-    assert y in z._prev
+    assert z._prev == OrderedSet([x, y])
     assert x._grad == 1.0
     assert y._grad == -1.0
     assert z.label == "z"

--- a/tests/test_scalar/test_tanh.py
+++ b/tests/test_scalar/test_tanh.py
@@ -3,6 +3,7 @@
 from math import isclose, tanh
 from nanograd.scalar import Scalar
 from nanograd.enums import Operation
+from ordered_set import OrderedSet
 
 def test_tanh_with_label() -> None:
     """Test the tanh method of the Scalar object with a label."""
@@ -13,6 +14,6 @@ def test_tanh_with_label() -> None:
 
     assert isclose(y.data, tanh(0.5))
     assert y.label == 'y'
-    assert y._prev == {x}
+    assert y._prev == OrderedSet([x])
     assert y._op == Operation.HYPERBOLIC_TANGENT
     assert isclose(x._grad, 1.0 - y.data**2)

--- a/tests/test_utils/test_topological_sort.py
+++ b/tests/test_utils/test_topological_sort.py
@@ -5,16 +5,16 @@ from nanograd.utils import topological_sort
 
 def test_topological_sort() -> None:
     """Test of the topological sort function."""
-    x1 = Scalar(1.0)
-    w1 = Scalar(-0.5)
-    x1w1 = x1 * w1
-    x2 = Scalar(-3.0)
-    w2 = Scalar(0.1)
-    x2w2 = x2 * w2
-    x1w1x2w2 = x1w1 + x2w2
-    b = Scalar(2.5)
-    x1w1x2w2b = x1w1x2w2 + b
-    out = x1w1x2w2b.tanh()
+    x1 = Scalar(1.0, label='x1')
+    w1 = Scalar(-0.5, label='w1')
+    x1w1 = x1.mul(w1, label='x1w1')
+    x2 = Scalar(-3.0, label='x2')
+    w2 = Scalar(0.1, label='w2')
+    x2w2 = x2.mul(w2, label='x2w2')
+    x1w1x2w2 = x1w1.add(x2w2, label='x1w1x2w2')
+    b = Scalar(2.5, label='b')
+    x1w1x2w2b = x1w1x2w2.add(b, label='x1w1x2w2b')
+    out = x1w1x2w2b.tanh(label='out')
     topo = topological_sort(out)
-
-    assert topo == {x1, w1, x1w1, x2, w2, x2w2, x1w1x2w2, b, x1w1x2w2b, out}
+    
+    assert topo == [x1, w1, x1w1, x2, w2, x2w2, x1w1x2w2, b, x1w1x2w2b, out]

--- a/tests/test_utils/test_topological_sort.py
+++ b/tests/test_utils/test_topological_sort.py
@@ -1,0 +1,20 @@
+"""Test suite for the topological sort function."""
+
+from nanograd.scalar import Scalar
+from nanograd.utils import topological_sort
+
+def test_topological_sort() -> None:
+    """Test of the topological sort function."""
+    x1 = Scalar(1.0)
+    w1 = Scalar(-0.5)
+    x1w1 = x1 * w1
+    x2 = Scalar(-3.0)
+    w2 = Scalar(0.1)
+    x2w2 = x2 * w2
+    x1w1x2w2 = x1w1 + x2w2
+    b = Scalar(2.5)
+    x1w1x2w2b = x1w1x2w2 + b
+    out = x1w1x2w2b.tanh()
+    topo = topological_sort(out)
+
+    assert topo == {x1, w1, x1w1, x2, w2, x2w2, x1w1x2w2, b, x1w1x2w2b, out}

--- a/tests/test_utils/test_topological_sort.py
+++ b/tests/test_utils/test_topological_sort.py
@@ -2,6 +2,7 @@
 
 from nanograd.scalar import Scalar
 from nanograd.utils import topological_sort
+from ordered_set import OrderedSet
 
 def test_topological_sort() -> None:
     """Test of the topological sort function."""
@@ -17,4 +18,4 @@ def test_topological_sort() -> None:
     out = x1w1x2w2b.tanh(label='out')
     topo = topological_sort(out)
     
-    assert topo == [x1, w1, x1w1, x2, w2, x2w2, x1w1x2w2, b, x1w1x2w2b, out]
+    assert topo == OrderedSet([x1, w1, x1w1, x2, w2, x2w2, x1w1x2w2, b, x1w1x2w2b, out])


### PR DESCRIPTION
Related to #14.

All the tasks have been completed and all acceptance criteria are met.

The `Scalar` class has been updated to use `OrderedSet` instead of the classic Python `set`. The `OrderedSet` ensures the order of elements added to the set. All unit tests have been reworked to accommodate this change.